### PR TITLE
fix: 修复 DocType 刷新后的标题显示

### DIFF
--- a/frappe/core/doctype/doctype/doctype.js
+++ b/frappe/core/doctype/doctype/doctype.js
@@ -50,9 +50,10 @@ frappe.ui.form.on("DocType", {
 		}
 
 		if (!frm.is_new() && !frm.doc.istable) {
+			const doctype_title = frappe.model.get_doc_title(frm.doc) || frm.doc.name;
 			const button_text = frm.doc.issingle
-				? __("Go to {0}", [__(frm.doc.name)])
-				: __("Go to {0} List", [__(frm.doc.name)]);
+				? __("Go to {0}", [__(doctype_title)])
+				: __("Go to {0} List", [__(doctype_title)]);
 			frm.add_custom_button(button_text, () => {
 				window.open(`/desk/${frappe.router.slug(frm.doc.name)}`);
 			});

--- a/frappe/public/js/frappe/views/breadcrumbs.js
+++ b/frappe/public/js/frappe/views/breadcrumbs.js
@@ -216,11 +216,11 @@ frappe.breadcrumbs = {
 			this.append_breadcrumb_element(
 				`/desk/${route}`,
 				frappe.model.get_translated_doctype_title(doctype_meta),
-				"title-text"
+				"doctype-title"
 			);
 		}
 
-		let list_crumb = this.$breadcrumbs.find("li a.title-text");
+		let list_crumb = this.$breadcrumbs.find("li a.doctype-title");
 		list_crumb.parent().addClass("ellipsis");
 	},
 


### PR DESCRIPTION
## 改动内容

- 为 DocType 列表面包屑使用独立的 CSS 类，避免表单页面标题刷新时覆盖面包屑文本。
- “转到列表”按钮优先显示 DocType 的标题字段；标题为空时回退到名称。

## 问题原因

DocType 面包屑与页面主标题共用了 `.title-text` 类，刷新表单时页面标题逻辑会把面包屑覆盖为当前记录的 `name`。同时，转到列表按钮原本直接读取 `frm.doc.name`，没有使用标题字段。

## 用户影响

刷新 DocType 编辑界面后，面包屑会正确显示“单据类型”，转到列表按钮会显示当前 DocType 的标题。

## 验证

- 执行 `bench build --app frappe`。
- 执行 JavaScript 语法检查与 `git diff --check`。
- 在 `development.localhost` 冷刷新验证：面包屑为“构建 / 单据类型 / 项目”，按钮为“转到项目列表”。
