### PR TITLE
Improve Desk lifecycle, sidebar, and app branding

### DIFF
--- a/cypress/integration/sidebar.js
+++ b/cypress/integration/sidebar.js
@@ -47,6 +47,20 @@ context("Sidebar", () => {
 			});
 	});
 
+	it("Toggles the Desk sidebar from above the user profile", () => {
+		cy.visit("/desk");
+		cy.window()
+			.its("frappe.app.sidebar")
+			.then((sidebar) => sidebar.open());
+
+		cy.get(".body-sidebar-container").should("have.class", "expanded");
+		cy.findByRole("button", { name: "Collapse Sidebar" }).click();
+		cy.get(".body-sidebar-container").should("not.have.class", "expanded");
+
+		cy.findByRole("button", { name: "Expand Sidebar" }).click();
+		cy.get(".body-sidebar-container").should("have.class", "expanded");
+	});
+
 	it("Verify attachment visibility config", () => {
 		cy.call("frappe.tests.ui_test_helpers.create_todo", {
 			description: "Sidebar Attachment ToDo",

--- a/frappe/app.py
+++ b/frappe/app.py
@@ -73,6 +73,29 @@ import frappe.website.website_generator  # web page doctypes
 Request.max_form_memory_size = None
 
 
+class _RequestClosingIterator(ClosingIterator):
+	def close(self):
+		if getattr(self, "_closed", False):
+			return
+		self._closed = True
+		try:
+			super().close()
+		except BaseException:
+			_destroy_request_context(preserve_exception=True)
+			raise
+		else:
+			frappe.destroy()
+
+
+def _destroy_request_context(*, preserve_exception: bool = False) -> None:
+	try:
+		frappe.destroy()
+	except BaseException:
+		if not preserve_exception:
+			raise
+		logging.getLogger(__name__).exception("Failed to destroy request context")
+
+
 def after_response_wrapper(app):
 	"""Wrap a WSGI application to call after_response hooks after we have responded.
 
@@ -80,15 +103,23 @@ def after_response_wrapper(app):
 
 	@functools.wraps(app)
 	def application(environ, start_response):
-		return ClosingIterator(
-			app(environ, start_response),
-			(
-				frappe.rate_limiter.update,
-				frappe.recorder.dump,
-				frappe.request.after_response.run,
-				frappe.destroy,
-			),
-		)
+		try:
+			response = app(environ, start_response)
+		except BaseException:
+			_destroy_request_context(preserve_exception=True)
+			raise
+		try:
+			return _RequestClosingIterator(
+				response,
+				(
+					frappe.rate_limiter.update,
+					frappe.recorder.dump,
+					frappe.request.after_response.run,
+				),
+			)
+		except BaseException:
+			_destroy_request_context(preserve_exception=True)
+			raise
 
 	return application
 

--- a/frappe/locale/zh.po
+++ b/frappe/locale/zh.po
@@ -4985,6 +4985,11 @@ msgstr "代码质询方法"
 msgid "Collapse"
 msgstr "收起"
 
+#: frappe/public/js/frappe/ui/sidebar/sidebar.html
+#: frappe/public/js/frappe/ui/sidebar/sidebar.js
+msgid "Collapse Sidebar"
+msgstr "收起边栏"
+
 #: frappe/public/js/frappe/form/controls/code.js:185
 msgctxt "Shrink code field."
 msgid "Collapse"
@@ -9686,6 +9691,10 @@ msgstr "现有角色"
 #: frappe/public/js/frappe/widgets/base_widget.js:159
 msgid "Expand"
 msgstr "展开"
+
+#: frappe/public/js/frappe/ui/sidebar/sidebar.js
+msgid "Expand Sidebar"
+msgstr "展开边栏"
 
 #: frappe/public/js/frappe/form/controls/code.js:186
 msgctxt "Enlarge code field."

--- a/frappe/public/js/frappe/ui/page.js
+++ b/frappe/public/js/frappe/ui/page.js
@@ -9,6 +9,7 @@
  * @param {string} opts.parent [HTMLElement] Parent element
  * @param {boolean} opts.single_column Whether to include sidebar
  * @param {string} [opts.sidebar_position] Position of sidebar (default None, "Left" or "Right")
+ * @param {"document" | "internal"} [opts.scroll_mode] Scroll owner (default "document")
  * @param {string} [opts.title] Page title
  * @param {Object} [opts.make_page]
  *
@@ -42,10 +43,23 @@ frappe.ui.Page = class Page {
 
 	make() {
 		this.wrapper = $(this.parent);
+		this.setup_scroll_mode();
 		this.add_main_section();
 		this.setup_scroll_handler();
 		this.setup_main_sidebar_toggle();
 		this.setup_mobile_awesomebar();
+	}
+
+	setup_scroll_mode() {
+		if (this.scroll_mode !== "internal") return;
+
+		const $main_section = this.wrapper.closest(".main-section");
+		this.wrapper.on("show.internal-scroll", () => {
+			$main_section.addClass("has-internal-scroll");
+		});
+		this.wrapper.on("hide.internal-scroll", () => {
+			$main_section.removeClass("has-internal-scroll");
+		});
 	}
 
 	setup_mobile_awesomebar() {

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.html
@@ -47,7 +47,16 @@
 						 <span> {%= __("Getting Started") %} </span>
 					</a>
 				</p>
-				<div class="nav-item dropdown dropdown-navbar-user dropdown-mobile mt-3">
+				<button
+					class="btn-reset collapse-sidebar-link"
+					type="button"
+					aria-label="{%= __("Collapse Sidebar") %}"
+					title="{%= __("Collapse Sidebar") %}"
+				>
+					{%= frappe.utils.icon("panel-right-open", "sm", "", "", "text-ink-gray-7 current-color", true) %}
+					<span>{%= __("Collapse Sidebar") %}</span>
+				</button>
+				<div class="nav-item dropdown dropdown-navbar-user dropdown-mobile">
 					<a
 						class="align-center btn-reset flex nav-link sidebar-user-button"
 						style="width: 100%; min-height: 40px;"

--- a/frappe/public/js/frappe/ui/sidebar/sidebar.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar.js
@@ -442,7 +442,6 @@ frappe.ui.Sidebar = class Sidebar {
 	}
 	make_sidebar() {
 		this.empty();
-		this.wrapper.find(".collapse-sidebar-link").removeClass("hidden");
 		if (this.editor.edit_mode) {
 			this.create_sidebar(this.editor.new_sidebar_items);
 		} else {
@@ -468,7 +467,6 @@ frappe.ui.Sidebar = class Sidebar {
 				"<div class='flex' style='padding: 30px'> No Sidebar Items </div>"
 			);
 			this.wrapper.find(".sidebar-items").append(no_items_message);
-			this.wrapper.find(".collapse-sidebar-link").addClass("hidden");
 		}
 		if (this.edit_mode) {
 			$(".edit-menu").removeClass("hidden");
@@ -587,10 +585,11 @@ frappe.ui.Sidebar = class Sidebar {
 		}
 
 		localStorage.setItem("sidebar-expanded", this.sidebar_expanded);
-		this.wrapper
-			.find(".body-sidebar .collapse-sidebar-link")
-			.find("use")
-			.attr("href", `#icon-panel-${direction}-open`);
+		const toggle_label = this.sidebar_expanded ? __("Collapse Sidebar") : __("Expand Sidebar");
+		const $toggle = this.wrapper.find(".body-sidebar .collapse-sidebar-link");
+		$toggle.attr({ "aria-label": toggle_label, title: toggle_label });
+		$toggle.find("span").text(toggle_label);
+		$toggle.find("use").attr("href", `#icon-panel-${direction}-open`);
 		this.sidebar_header.toggle_width(this.sidebar_expanded);
 		$(document).trigger("sidebar-expand", {
 			sidebar_expand: this.sidebar_expanded,

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.html
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.html
@@ -2,9 +2,11 @@
     class="sidebar-item-container {%= item.is_editable ? 'is-draggable' : '' %} {% if (item.type == 'Section Break') { %}section-item{% } %}"
     item-name="{{ item.label }}"
     data-id="{{ item.label }}"
-    title="{{ item.label }}"
+    {% if (item.type != "Section Break") { %}
+    title="{{ item.label }}{% if (item.parent) { %} · {{ item.parent.label }}{% } %}"
     data-toggle="tooltip"
     data-placement="right"
+    {% } %}
 >
     <div
         class="standard-sidebar-item {%= item.indent ? 'indent' : '' %}">

--- a/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
+++ b/frappe/public/js/frappe/ui/sidebar/sidebar_item.js
@@ -270,7 +270,7 @@ frappe.ui.sidebar_item.TypeSectionBreak = class SectionBreakSidebarItem extends 
 		const me = this;
 		let current_sidebar_state = this.section_breaks_state[this.workspace_title];
 		for (const [element_name, collapsed] of Object.entries(current_sidebar_state)) {
-			if ($(this.wrapper).attr("title") == element_name) {
+			if (this.item.label == element_name) {
 				me.collapsed = collapsed;
 				me.toggle();
 			}
@@ -297,8 +297,7 @@ frappe.ui.sidebar_item.TypeSectionBreak = class SectionBreakSidebarItem extends 
 			this.section_breaks_state[this.workspace_title] = {};
 		}
 
-		const title = this.wrapper.attr("title");
-		this.section_breaks_state[this.workspace_title][title] = this.collapsed;
+		this.section_breaks_state[this.workspace_title][this.item.label] = this.collapsed;
 
 		localStorage.setItem("section-breaks-state", JSON.stringify(this.section_breaks_state));
 	}

--- a/frappe/public/js/frappe/views/pageview.js
+++ b/frappe/public/js/frappe/views/pageview.js
@@ -111,6 +111,9 @@ frappe.views.Page = class Page {
 			me.trigger_page_event("on_page_show");
 			me.trigger_page_event("refresh");
 		});
+		$(this.wrapper).on("hide", function () {
+			me.trigger_page_event("on_page_hide");
+		});
 	}
 
 	trigger_page_event(eventname) {

--- a/frappe/public/scss/desk/main.scss
+++ b/frappe/public/scss/desk/main.scss
@@ -41,6 +41,11 @@ body {
 	overflow-x: hidden;
 	overflow-y: visible;
 	scrollbar-gutter: stable;
+
+	&.has-internal-scroll {
+		overflow: hidden;
+		scrollbar-gutter: auto;
+	}
 }
 .sticky-top {
 	z-index: 1019;

--- a/frappe/public/scss/desk/sidebar.scss
+++ b/frappe/public/scss/desk/sidebar.scss
@@ -152,6 +152,30 @@
 		}
 	}
 
+	.collapse-sidebar-link {
+		width: 100%;
+		min-height: 40px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		color: var(--ink-gray-8);
+		font-size: var(--text-sm);
+		border-radius: 8px;
+
+		&:hover {
+			@include hover-mixin();
+		}
+
+		svg {
+			margin: 0;
+			flex: 0 0 auto;
+		}
+
+		span {
+			display: none;
+		}
+	}
+
 	.nav-item {
 		padding: 4px 0px;
 	}
@@ -172,19 +196,14 @@
 		width: var(--sidebar-width);
 
 		.collapse-sidebar-link {
-			text-decoration: none;
-			font-size: var(--text-sm);
-			display: flex;
-			align-items: center;
-			svg {
-				margin: 0px;
-				flex: 0 0 auto;
-			}
+			justify-content: flex-start;
+			padding: 0 7px;
+
 			span {
+				display: block;
 				margin-left: 10px;
 				@include truncate();
 			}
-			@include transition(all, 0.3s, cubic-bezier(0.4, 0, 0.2, 1));
 		}
 
 		.nav-item {

--- a/frappe/tests/test_app_cleanup.py
+++ b/frappe/tests/test_app_cleanup.py
@@ -1,0 +1,120 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from frappe.app import after_response_wrapper
+from frappe.tests import UnitTestCase
+
+
+class TestAfterResponseWrapper(UnitTestCase):
+	def test_destroys_context_when_application_raises(self):
+		def failing_application(_environ, _start_response):
+			raise RuntimeError("request failed")
+
+		with patch("frappe.destroy") as destroy, pytest.raises(RuntimeError, match="request failed"):
+			after_response_wrapper(failing_application)({}, lambda *_args: None)
+
+		destroy.assert_called_once_with()
+
+	def test_preserves_application_error_when_destroy_also_raises(self):
+		def failing_application(_environ, _start_response):
+			raise RuntimeError("request failed")
+
+		with (
+			patch("frappe.destroy", side_effect=RuntimeError("destroy failed")) as destroy,
+			pytest.raises(RuntimeError, match="request failed"),
+		):
+			after_response_wrapper(failing_application)({}, lambda *_args: None)
+
+		destroy.assert_called_once_with()
+
+	def test_destroys_context_when_cleanup_callback_raises(self):
+		def application(_environ, _start_response):
+			return [b"ok"]
+
+		with (
+			patch("frappe.rate_limiter.update", side_effect=RuntimeError("cleanup failed")),
+			patch("frappe.request", Mock(after_response=Mock())),
+			patch("frappe.destroy") as destroy,
+		):
+			response = after_response_wrapper(application)({}, lambda *_args: None)
+			with pytest.raises(RuntimeError, match="cleanup failed"):
+				response.close()
+
+		destroy.assert_called_once_with()
+
+	def test_destroys_context_when_response_iterator_creation_raises(self):
+		class FailingIterable:
+			def __iter__(self):
+				raise RuntimeError("iterator creation failed")
+
+		with (
+			patch("frappe.request", Mock(after_response=Mock())),
+			patch("frappe.destroy") as destroy,
+			pytest.raises(RuntimeError, match="iterator creation failed"),
+		):
+			after_response_wrapper(lambda *_args: FailingIterable())({}, lambda *_args: None)
+
+		destroy.assert_called_once_with()
+
+	def test_closes_request_context_only_once(self):
+		with (
+			patch("frappe.rate_limiter.update") as update_rate_limit,
+			patch("frappe.recorder.dump") as dump_recording,
+			patch("frappe.request", Mock(after_response=Mock())) as request,
+			patch("frappe.destroy") as destroy,
+		):
+			response = after_response_wrapper(lambda *_args: [b"ok"])({}, lambda *_args: None)
+			response.close()
+			response.close()
+
+		update_rate_limit.assert_called_once_with()
+		dump_recording.assert_called_once_with()
+		request.after_response.run.assert_called_once_with()
+		destroy.assert_called_once_with()
+
+	def test_preserves_cleanup_error_when_destroy_also_raises(self):
+		with (
+			patch("frappe.rate_limiter.update", side_effect=RuntimeError("cleanup failed")),
+			patch("frappe.request", Mock(after_response=Mock())),
+			patch("frappe.destroy", side_effect=RuntimeError("destroy failed")) as destroy,
+		):
+			response = after_response_wrapper(lambda *_args: [b"ok"])({}, lambda *_args: None)
+			with pytest.raises(RuntimeError, match="cleanup failed"):
+				response.close()
+
+		destroy.assert_called_once_with()
+
+	def test_destroys_context_when_response_close_raises(self):
+		class FailingCloseIterable:
+			def __iter__(self):
+				return iter((b"ok",))
+
+			def close(self):
+				raise RuntimeError("response close failed")
+
+		with (
+			patch("frappe.request", Mock(after_response=Mock())),
+			patch("frappe.destroy") as destroy,
+		):
+			response = after_response_wrapper(lambda *_args: FailingCloseIterable())({}, lambda *_args: None)
+			with pytest.raises(RuntimeError, match="response close failed"):
+				response.close()
+
+		destroy.assert_called_once_with()
+
+	def test_destroys_context_when_after_response_callback_raises(self):
+		after_response = Mock()
+		after_response.run.side_effect = RuntimeError("after response failed")
+
+		with (
+			patch("frappe.rate_limiter.update"),
+			patch("frappe.recorder.dump"),
+			patch("frappe.request", Mock(after_response=after_response)),
+			patch("frappe.destroy") as destroy,
+		):
+			response = after_response_wrapper(lambda *_args: [b"ok"])({}, lambda *_args: None)
+			with pytest.raises(RuntimeError, match="after response failed"):
+				response.close()
+
+		destroy.assert_called_once_with()

--- a/frappe/tests/test_desk.py
+++ b/frappe/tests/test_desk.py
@@ -1,0 +1,62 @@
+from frappe.tests import UnitTestCase
+from frappe.www.desk import get_app_splash_image, get_route_variants
+
+
+class TestDeskSplashImage(UnitTestCase):
+	def test_uses_fallback_without_matching_app(self):
+		self.assertEqual(
+			get_app_splash_image({"app_data": []}, "/desk", "/custom-splash.svg"),
+			"/custom-splash.svg",
+		)
+
+	def test_matches_app_and_desk_route_variants(self):
+		boot = {
+			"app_data": [
+				{
+					"app_name": "example",
+					"app_route": "/app/example",
+					"app_logo_url": ["/old-logo.svg", "/example-logo.svg"],
+				}
+			]
+		}
+
+		for route in ("/app/example/report", "/desk/example/report"):
+			with self.subTest(route=route):
+				self.assertEqual(
+					get_app_splash_image(boot, route, "/fallback.svg"),
+					"/example-logo.svg",
+				)
+
+	def test_uses_longest_matching_route(self):
+		boot = {
+			"app_data": [
+				{"app_name": "parent", "app_route": "/app/reports", "app_logo_url": "/parent.svg"},
+				{
+					"app_name": "child",
+					"app_route": "/app/reports/sales",
+					"app_logo_url": "/child.svg",
+				},
+			]
+		}
+
+		self.assertEqual(
+			get_app_splash_image(boot, "/app/reports/sales/monthly", "/fallback.svg"),
+			"/child.svg",
+		)
+
+	def test_uses_apps_screen_route_when_app_home_differs(self):
+		boot = {
+			"app_data": [{"app_name": "example", "app_route": "/app/home", "app_logo_url": "/example.svg"}]
+		}
+		app_screen_items = [{"name": "example", "route": "/app/example"}]
+
+		self.assertEqual(
+			get_app_splash_image(boot, "/app/example", "/fallback.svg", app_screen_items),
+			"/example.svg",
+		)
+
+	def test_route_variants_ignore_query_and_trailing_slash(self):
+		self.assertEqual(
+			get_route_variants("/app/example/?view=list"),
+			("/app/example", "/desk/example"),
+		)

--- a/frappe/www/desk.py
+++ b/frappe/www/desk.py
@@ -6,6 +6,7 @@ no_cache = 1
 
 import json
 import re
+from typing import Any
 from urllib.parse import urlencode
 
 import frappe
@@ -19,6 +20,7 @@ CLOSING_SCRIPT_TAG_PATTERN = re.compile(r"</script\>")
 
 def get_context(context):
 	desk_favicon = frappe.get_hooks("desk_favicon")
+	default_favicon = desk_favicon[-1] if desk_favicon else context.get("favicon")
 
 	if frappe.session.user == "Guest":
 		frappe.response["status_code"] = 403
@@ -59,7 +61,13 @@ def get_context(context):
 			"csrf_token": csrf_token,
 			"google_analytics_id": frappe.conf.get("google_analytics_id"),
 			"google_analytics_anonymize_ip": frappe.conf.get("google_analytics_anonymize_ip"),
-			"favicon": desk_favicon[-1] if desk_favicon else context.get("favicon"),
+			"favicon": default_favicon,
+			"splash_image": get_app_splash_image(
+				boot,
+				frappe.request.path,
+				context.get("splash_image") or default_favicon,
+				hooks.get("add_to_apps_screen", []),
+			),
 			"app_name": (
 				frappe.get_website_settings("app_name") or frappe.get_system_settings("app_name") or "Frappe"
 			),
@@ -67,3 +75,51 @@ def get_context(context):
 	)
 
 	return context
+
+
+def get_app_splash_image(
+	boot: dict[str, Any],
+	request_path: str,
+	fallback: str | None,
+	app_screen_items: list[dict[str, Any]] | None = None,
+) -> str | None:
+	request_path = f"/{request_path.strip('/')}"
+	matched_app = None
+	matched_route_length = 0
+	app_screen_routes = {
+		item.get("name"): item.get("route")
+		for item in app_screen_items or []
+		if item.get("name") and item.get("route")
+	}
+
+	for app in boot.get("app_data", []):
+		routes = (app.get("app_route"), app_screen_routes.get(app.get("app_name")))
+		for route in routes:
+			for app_route in get_route_variants(route):
+				if request_path == app_route or request_path.startswith(f"{app_route}/"):
+					if len(app_route) > matched_route_length:
+						matched_app = app
+						matched_route_length = len(app_route)
+
+	if not matched_app:
+		return fallback
+
+	app_logo = matched_app.get("app_logo_url")
+	if isinstance(app_logo, (list, tuple)):
+		app_logo = app_logo[-1] if app_logo else None
+
+	return app_logo or fallback
+
+
+def get_route_variants(route: str | None) -> tuple[str, ...]:
+	route = (route or "").split("?", 1)[0].rstrip("/")
+	if not route:
+		return ()
+
+	variants = [route]
+	if route.startswith("/app/"):
+		variants.append(f"/desk/{route.removeprefix('/app/')}")
+	elif route.startswith("/desk/"):
+		variants.append(f"/app/{route.removeprefix('/desk/')}")
+
+	return tuple(variants)


### PR DESCRIPTION
## 变更说明

- 确保 WSGI 应用、响应迭代器或 after-response 回调异常时仍释放 Frappe 请求上下文，并保留原始异常。
- 改进 Desk 侧边栏折叠入口、可访问性标签、子项提示和折叠状态持久化。
- 为 Desk Page 增加内部滚动模式和 `on_page_hide` 生命周期事件。
- 根据入口路由在 Desk splash screen 中展示对应应用 logo，并保留 Website Settings 自定义 splash 作为 fallback。

## Review 修正

- 修复初始实现覆盖 Website Settings `splash_image` 的兼容性回归。
- 将请求清理测试改为 Frappe runner 可发现的 `UnitTestCase`，并补充 splash 路由单元测试。

## 验证

- `pre-commit run --files <所有变更文件>`
- `bench --site test.localhost run-tests --app frappe --module frappe.tests.test_app_cleanup`（8 passed）
- `bench --site test.localhost run-tests --app frappe --module frappe.tests.test_desk`（5 passed）
- `bench build --app frappe`
- `git diff --check upstream/version-16...HEAD`

Cypress sidebar 用例未运行：本机存在 Cypress npm 包，但二进制未安装；对应文件已通过 Prettier，且构建通过。
